### PR TITLE
Two improvements

### DIFF
--- a/BuildSettingExtractor/BuildSettingExtractor.m
+++ b/BuildSettingExtractor/BuildSettingExtractor.m
@@ -69,7 +69,7 @@ static NSString * const XcodeCompatibilityVersionString = @"Xcode 3.2";
         [NSApp presentError:error];
     } else {
 
-        NSDictionary *projectPlist = [NSPropertyListSerialization propertyListWithData:fileData options:kCFPropertyListImmutable format:NULL error:&error];
+        NSDictionary *projectPlist = [NSPropertyListSerialization propertyListWithData:fileData options:NSPropertyListImmutable format:NULL error:&error];
 
         if (!projectPlist) {
             [NSApp presentError:error];
@@ -133,6 +133,7 @@ static NSString * const XcodeCompatibilityVersionString = @"Xcode 3.2";
             // If the config name is not the shared config, we need to import the shared config
             if (![configName isEqualToString:self.sharedConfigName]) {
                 NSString *configFilename = [self configFilenameWithTargetName:targetName configName:self.sharedConfigName];
+                configFilename = configFilename.lastPathComponent;  // in case separator is "/"
                 NSString *includeDirective = [NSString stringWithFormat:@"\n\n#include \"%@\"", configFilename];
                 configFileString = [configFileString stringByAppendingString:includeDirective];
             }
@@ -154,7 +155,11 @@ static NSString * const XcodeCompatibilityVersionString = @"Xcode 3.2";
 
 
             NSURL *fileURL = [destinationURL URLByAppendingPathComponent:filename];
-
+            if ([filename containsString: @"/"]) {
+                [[NSFileManager defaultManager] createDirectoryAtURL: fileURL.URLByDeletingLastPathComponent
+                                         withIntermediateDirectories: NO attributes: nil error: nil];
+            }
+            
             BOOL success = [configFileString writeToURL:fileURL atomically:YES encoding:NSUTF8StringEncoding error:nil];
             if (!success) NSLog(@"No success with %@", fileURL);
         }];

--- a/BuildSettingExtractor/BuildSettingExtractor.m
+++ b/BuildSettingExtractor/BuildSettingExtractor.m
@@ -196,6 +196,10 @@ static NSString * const XcodeCompatibilityVersionString = @"Xcode 3.2";
     // Sort build settings by name for easier reading and testing. Case insensitive compare should stay stable regardess of locale.
     NSArray *sortedKeys = [[buildSettings allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
 
+    NSUInteger maxKeyLen = 8;
+    for (NSString* key in sortedKeys)
+        maxKeyLen = MAX(maxKeyLen, key.length);
+
     BOOL firstKey = YES;
     for (NSString *key in sortedKeys) {
         id value = buildSettings[key];
@@ -210,11 +214,14 @@ static NSString * const XcodeCompatibilityVersionString = @"Xcode 3.2";
             }
         }
 
-        if ([value isKindOfClass:[NSString class]]) {
-            [string appendFormat:@"%@ = %@\n", key, value];
+        [string appendString: key];
+        for (NSUInteger len = key.length; len < maxKeyLen; len++)
+            [string appendString: @" "];
 
+        if ([value isKindOfClass:[NSString class]]) {
+            [string appendFormat:@" = %@\n", value];
         } else if ([value isKindOfClass:[NSArray class]]) {
-            [string appendFormat:@"%@ = %@\n", key, [value componentsJoinedByString:@" "]];
+            [string appendFormat:@" = %@\n", [value componentsJoinedByString:@" "]];
         } else {
             [NSException raise:@"Should not get here!" format:@"Unexpected class: %@ in %s", [value class], __PRETTY_FUNCTION__];
         }


### PR DESCRIPTION
1. Allow "/" as a separator string, to put the config files into subfolders grouped by target.
2. Add spaces after the "=" in the config files to align the values neatly.
3. Three improvements! Fixed a (harmless) compiler warning about an incorrect enum value.
