### PR TITLE
Update Metal.xcplugin Strings for Xcode 12

### DIFF
--- a/BuildSettingExtractor/BuildSettingInfoSubpaths.plist
+++ b/BuildSettingExtractor/BuildSettingInfoSubpaths.plist
@@ -40,6 +40,8 @@
 			<array>
 				<string>Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Xcode/Specifications/Native Build System.strings</string>
 				<string>Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Xcode/Specifications/Native Build System.xcspec</string>
+				<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Metal.xcplugin/Contents/Resources/Metal Compiler.strings</string>
+				<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Metal.xcplugin/Contents/Resources/MetalCompiler.strings</string>
 			</array>
 		</array>
 		<key>0900</key>
@@ -54,7 +56,8 @@
 		<key>1200</key>
 		<array>
 			<array>
-				<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Metal.xcplugin/Contents/Resources/MetalLinker.strings</string>
+				<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Metal.xcplugin/Contents/Resources/en.lproj/com.apple.compilers.metal.strings</string>
+				<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Metal.xcplugin/Contents/Resources/en.lproj/com.apple.compilers.metal-linker.strings</string>
 			</array>
 		</array>
 	</dict>
@@ -82,8 +85,8 @@
 			<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/XCLanguageSupport.xcplugin/Contents/Resources/SwiftBuildSettings.strings</string>
 		</array>
 		<array>
-			<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Metal.xcplugin/Contents/Resources/Metal Compiler.strings</string>
-			<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Metal.xcplugin/Contents/Resources/MetalCompiler.strings</string>
+			<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Metal.xcplugin/Contents/Resources/en.lproj/com.apple.compilers.metal.strings</string>
+			<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Metal.xcplugin/Contents/Resources/en.lproj/com.apple.compilers.metal-linker.strings</string>
 		</array>
 		<array>
 			<string>Contents/PlugIns/Xcode3Core.ideplugin/Contents/SharedSupport/Developer/Library/Xcode/Plug-ins/Core Data.xcplugin/Contents/Resources/en.lproj/com.apple.compilers.model.coredata.strings</string>


### PR DESCRIPTION
The strings locations for Metal have moved in Xcode 12. This change updates the `BuildSettingInfoSubpaths.plist` file with the new paths.