### PR TITLE
Add Xcode 11.4 to the compatible Xcode versions list

### DIFF
--- a/BuildSettingExtractor/BuildSettingExtractor.m
+++ b/BuildSettingExtractor/BuildSettingExtractor.m
@@ -15,7 +15,7 @@ static NSSet *XcodeCompatibilityVersionStringSet() {
     static NSSet *_compatibilityVersionStringSet;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        _compatibilityVersionStringSet = [NSSet setWithObjects:@"Xcode 3.2", @"Xcode 6.3", @"Xcode 8.0", @"Xcode 9.3", @"Xcode 10.0", @"Xcode 11.0", @"Xcode 12.0", nil];
+        _compatibilityVersionStringSet = [NSSet setWithObjects:@"Xcode 3.2", @"Xcode 6.3", @"Xcode 8.0", @"Xcode 9.3", @"Xcode 10.0", @"Xcode 11.0", @"Xcode 11.4", @"Xcode 12.0", nil];
     });
     return _compatibilityVersionStringSet;
 }


### PR DESCRIPTION
When trying to use BuildSettingExtractor on an Xcode project with its project set to "Xcode 11.4-compatible", the extraction fails.

Xcode includes a specific project format for Xcode 11.4, but Xcode 11.4 is not currently in the compatible versions list within BuildSettingExtractor. This PR adds the version.

I'm not familiar enough with the project to know the implications of adding this. All of the unit tests do pass though (assuming you merge in my changes in #71 first), and I built the app and ran it against an Xcode with a project version set to Xcode 11.4. It seemed to work without a problem.

I don't know how best to test it more than that though. Let me know if there's any other testing you'd like me to do.